### PR TITLE
Implement a new Start in Free Camera option

### DIFF
--- a/sadx-speedrun-mod/configschema.xml
+++ b/sadx-speedrun-mod/configschema.xml
@@ -20,6 +20,9 @@
 	  <Property name="CCEF" type="bool" defaultvalue="true" display="Camera Code Error Fix">
 		<HelpText>CCEF fixes a bug so that the camera doesn't reset to Auto Cam when set to Free Cam (Recommended)</HelpText>
 	  </Property>
+	  <Property name="FreeCam" type="bool" defaultvalue="false" display="Start in Free Camera">
+		<HelpText>Start the game directly in Free Camera, you need CCEF enabled for this to work</HelpText>
+	  </Property>
 	</Group>
   </Groups>
   <Enums>

--- a/sadx-speedrun-mod/mod.cpp
+++ b/sadx-speedrun-mod/mod.cpp
@@ -2,6 +2,7 @@
 #include "modules.h"
 
 static bool isQuickSaveEnabled;
+static bool isFreeCamEnabled;
 
 static char* accessibleMemory; // For referencing variables externally 
 
@@ -13,6 +14,7 @@ extern "C"
 		const IniFile* configFile = new IniFile(std::string(path) + "\\config.ini");
 
 		isQuickSaveEnabled = configFile->getBool("QuickSaveSettings", "Enabled", false);
+		isFreeCamEnabled = configFile->getBool("OtherSettings", "FreeCam", false);
 		std::string premadeSave = configFile->getString("QuickSaveSettings", "PremadeFile", "Custom");
 		std::string saveFilePath = configFile->getString("QuickSaveSettings", "SaveFilePath");
 		int save_num = configFile->getInt("QuickSaveSettings", "SaveNum", 99);
@@ -55,6 +57,9 @@ extern "C"
 		// Egg Hornet Crash Fix
 		WriteNop<3>((void*) 0x533939);
 		WriteNop<2>((void*) 0x440EF5);
+
+		if (isFreeCamEnabled)
+			WriteData<uint8_t>((uint8_t*) 0x03B2CBA8, 7);
 	}
 
 	__declspec(dllexport) void __cdecl OnFrame()

--- a/sadx-speedrun-mod/mod.cpp
+++ b/sadx-speedrun-mod/mod.cpp
@@ -2,7 +2,6 @@
 #include "modules.h"
 
 static bool isQuickSaveEnabled;
-static bool isFreeCamEnabled;
 
 static char* accessibleMemory; // For referencing variables externally 
 
@@ -14,11 +13,11 @@ extern "C"
 		const IniFile* configFile = new IniFile(std::string(path) + "\\config.ini");
 
 		isQuickSaveEnabled = configFile->getBool("QuickSaveSettings", "Enabled", false);
-		isFreeCamEnabled = configFile->getBool("OtherSettings", "FreeCam", false);
 		std::string premadeSave = configFile->getString("QuickSaveSettings", "PremadeFile", "Custom");
 		std::string saveFilePath = configFile->getString("QuickSaveSettings", "SaveFilePath");
 		int save_num = configFile->getInt("QuickSaveSettings", "SaveNum", 99);
 		bool isCCEF_Enabled = configFile->getBool("OtherSettings", "CCEF", true);
+		bool isFreeCamEnabled = configFile->getBool("OtherSettings", "FreeCam", false);
 		
 		delete configFile;
 		// Config File End
@@ -53,13 +52,13 @@ extern "C"
 			WriteData<uint16_t>((uint16_t*) 0x434870, 0x0D81);
 			WriteData<uint16_t>((uint16_t*) 0x438330, 0x0D81);
 		}
+		
+		if (isFreeCamEnabled)
+			WriteData<uint8_t>((uint8_t*) 0x03B2CBA8, 7);
 
 		// Egg Hornet Crash Fix
 		WriteNop<3>((void*) 0x533939);
 		WriteNop<2>((void*) 0x440EF5);
-
-		if (isFreeCamEnabled)
-			WriteData<uint8_t>((uint8_t*) 0x03B2CBA8, 7);
 	}
 
 	__declspec(dllexport) void __cdecl OnFrame()


### PR DESCRIPTION
This is a new option that requires CCEF to be enabled and will start the
game in Free Camera, removing the need to do some extra work before
starting some runs